### PR TITLE
extending model function - availability.js

### DIFF
--- a/sfra_training/cartridge/models/product/decorators/availability.js
+++ b/sfra_training/cartridge/models/product/decorators/availability.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var resource = require('dw/web/Resource');
+
+module.exports = function (object, quantity, minOrderQuantity, availabilityModel) {
+    //invoke the availability model on the base
+    base.call(this, object, quantity, minOrderQuantity, availabilityModel);
+
+    Object.defineProperty(object, 'ats', {
+        enumerable: true,
+        value: getATSMessage(availabilityModel)
+    });
+};
+
+function getATSMessage(availabilityModel){
+    var ATS = {};
+    var inventoryRecord = availabilityModel.inventoryRecord;
+    if(inventoryRecord) {
+        ATS.messages.push(
+            Resource.msgf(
+                'label.quantity.in.stock',
+                'common',
+                null,
+                inventoryRecord.ATS.value
+            )
+        );
+    }
+    return ATS;
+}


### PR DESCRIPTION
exending model function -- 
--------------------------
file should be same level and same name

F:\dev\storefront-reference-architecture\cartridges\app_storefront_base\cartridge\models\cart.js
function CartModel(basket) {

F:\dev\plugin_instorepickup\cartridges\plugin_instorepickup\cartridge\models\cart.js
create same function name

var base = module.superModule;
function CartModel(basket) {
    base.call(this, basket); //calling base cartride function
    this.disableShippingMethod = '';
    if (hasPickupInstoreItem(basket)) {
        this.disableShippingMethod = 'disabled';
    }
}

CartModel.prototype = Object.create(base.prototype); //adding this line mandatory

module.exports = CartModel;

