### PR TITLE
Localize an ISML Template

### DIFF
--- a/sfra_training/cartridge/templates/default/basket.isml
+++ b/sfra_training/cartridge/templates/default/basket.isml
@@ -6,11 +6,12 @@
     <isif condition="${pdict.basketModel.getProductLineItems().isEmpty()}">
         No basket exists
     <iselse/>
+    <h2>${Resource.msg('title.cart','cart',null)}</h2>
     <isloop items="${pdict.basketModel.items}" var="lineItem" status="loopstate">
         <!--- name and remove buttons --->
-        <isinclude template="cart/productCard/cartProductCardHeader" />
-        <isinclude template="cart/productCard/cartProductCardProductPrice" />
-        <isinclude template="cart/productCard/cartProductCardAvailability" />
+        ${Resource.msg('product.name','cart',null)} <isinclude template="cart/productCard/cartProductCardHeader" />
+        ${Resource.msg('product.price','cart',null)} <isinclude template="cart/productCard/cartProductCardProductPrice" />
+        ${Resource.msg('product.availability','cart',null)} <isinclude template="cart/productCard/cartProductCardAvailability" />
     </isloop>
 </isif>
 </isdecorate>

--- a/sfra_training/cartridge/templates/resources/cart.properties
+++ b/sfra_training/cartridge/templates/resources/cart.properties
@@ -1,0 +1,3 @@
+product.name=Product Name
+product.availability=Availability
+product.price=Price

--- a/sfra_training/cartridge/templates/resources/cart_es.properties
+++ b/sfra_training/cartridge/templates/resources/cart_es.properties
@@ -1,0 +1,4 @@
+product.name=Nombre del Producto
+product.availability=Disponibilidad
+product.price=Precio
+title.cart=tu carrito


### PR DESCRIPTION
Localize an ISML Template

 Enable a locale in Business Manager

Locales must be enabled in Business Manager in order for the merchants to be able to enter localized data in the tool.  Without enabled locales, everything gets stored in the default locale.  Study the [Localization](https://documentation.b2c.commercecloud.salesforce.com/DOC2/topic/com.demandware.dochelp/content/b2c_commerce/topics/localization/b2c_localization.html) documentation for details.
Also, in the storefront, the locale is part of the URL. When you browse [https://<your_sandbox>/on/demandware.store/Sites-RefArch-Site/en_US/Product-Show?pid=25686514M](https://zzpa-002.sandbox.us01.dx.commercecloud.salesforce.com/on/demandware.store/Sites-RefArch-Site/en_US/Product-Show?pid=25686514M), the en_US represents the English language, US region.  This locale identifier drives the following logic:

* The Resource bundles to use.  Note: you already used a resource bundle in a previous activity.
* The localized templates, if they exist in the cartridge

For the following exercise, check the locales that appear enabled in the RefArch site in Business Manager:

1. Select the RefArch site
2. Navigate to Merchant Tools >  Site Preferences > Locales
3. Notice the 2 locales that are already enabled for the site
4. Enable the es (Spanish) locale
5. Click Apply to save this change

Localize a template

1. Open the basket.isml template from your sfra_training cartridge.
2. For each local include that you are using inside the loop, add a Resource.msg() to print a localized string:
3. ${Resource.msg('product.name','cart',null)} <isinclude template="cart/productCard/cartProductCardHeader" />
    ${Resource.msg('product.price','cart',null)} <isinclude template="cart/productCard/cartProductCardProductPrice" />
    ${Resource.msg('product.availability','cart',null)} <isinclude template="cart/productCard/cartProductCardAvailability" />
4. In the sfra_training cartridge, create a templates/resources/cart.properties file.  This file will add localized strings that don’t exist in the resource bundle of the same name in the base cartridge:
5. product.name=Product Name
    product.availability=Availability
    product.price=Price
6. Create another cart_es.properties in the same folder, but with Spanish localized strings:
7. product.name=Nombre del Producto
    product.availability=Disponibilidad
    product.price=Precio
8. Test your Basket-Show route using several locales:
    1. .../default/Basket-Show: uses the default locale bundle (cart.properties).
    2. .../en_US/Basket-Show:  the same as above.  Why? Since there is no localized cart_en_US (or cart_en), the localization engine defaults to the default locale.
    3. .../es/Basket-Show: uses the Spanish locale strings (cart_es.properties) 
9. Notice that you did not have to modify your basket.isml template in order to use different locales: the localization engine looks for the resource bundle strings using the cartridge path order.
10. Now, use a localized string from the cart.properties to prove the statement above:
11. <h2>${Resource.msg('title.cart','cart',null)}</h2>

1. Refresh the page: notice that the title is still in English. 
2. Localize the title.cart string in your Spanish resource bundle.