### PR TITLE
remote-include

### DIFF
--- a/sfra_training/cartridge/templates/default/basket.isml
+++ b/sfra_training/cartridge/templates/default/basket.isml
@@ -1,4 +1,3 @@
-<isdecorate template="common/layout/page">
     <isscript>
         var assets = require('*/cartridge/scripts/assets.js');
         assets.addCss('/css/cart.css');
@@ -14,4 +13,3 @@
         ${Resource.msg('product.availability','cart',null)} <isinclude template="cart/productCard/cartProductCardAvailability" />
     </isloop>
 </isif>
-</isdecorate>

--- a/sfra_training/cartridge/templates/default/home/homePage.isml
+++ b/sfra_training/cartridge/templates/default/home/homePage.isml
@@ -1,5 +1,6 @@
 <isdecorate template="common/layout/page">
 <p>Use of prepend/append/replace using viewData: ${pdict.param1}</p>
+<isinclude url="${URLUtils.url('Basket-Show')}" />
     <!-- +1.888.555.0199 --><!--This phone is a requirement to support existing Gomez monitor of SiteGenesis. Demandware customers can remove this.-->
     <div class="home-main homepage">
         <isslot id="home-main-m" description="Main home page slot." context="global" />


### PR DESCRIPTION
Use a Remote Include to Manage Caching

In this exercise you will update your homepage (which is cached), and remote include your Basket-Show controller route, which is not cached. Homepage content can be safely cached, but the basket content is specific to each session, and therefore should not be cached.

1. In your sfra_training cartridge, locate the basket.isml template. 
2. Remove the enclosing decorator tags:  the homepage will now be the decorated template.
3. Open the Basket.js controller: in the Show route, make sure there is no caching middleware being invoked.  You don’t want the basket getting cached.
4. Test the Basket-Show controller after adding a few items to the basket: it should still work as before.

Reuse an existing route as a remote include

1. Locate the Home.js controller in your sfra_training cartridge.  If you don’t have one, you need to complete the Controllers course and follow the exercises. 
2. Study the Home-Show route: which cache middleware method is being used?  How many hours is the homepage cached?
3. Test that your Home-Show route still works:  homepage appears, no errors show.  You can ignore the nulls that appear if you did not complete the Controllers course.
4. Review your version of homePage.isml in the sfra_training cartridge:
    1. It uses a decorator already
    2. Locate the custom code that you added to test prepend/append.
5. Below that code, add a remote include that executes the Basket-Show route. Be extremely careful with the syntax of the url parameter.  Most people miss a character or two when typing this tag:
6. <isinclude url="${URLUtils.url('Basket-Show')}" />
7. Study the [URLUtils class](https://documentation.b2c.commercecloud.salesforce.com/DOC2/topic/com.demandware.dochelp/DWAPI/scriptapi/html/api/class_dw_web_URLUtils.html) to learn more about the different methods, and how to pass data to a remote include.  

Note: the pdict from homePage.isml is not automatically passed to the remote include.  Lucky for you, the Basket-Show route gets all its own data via a model.

1. Test the homepage (Home-Show route) in the storefront: your basket should appear in the beginning of the page.

Use the Toolkit to investigate caching on the page

Business Manager has a tool that allows you to quickly identify the caching used by different areas of the page as a result of remore includes:

1. Select the RefArch site
2. Click Toolkit from the main menu
3. A new tab appears with the homepage displayed
4. Click the Cache Info tool: 
5. 
6. Examine the different caching on the page:
    1. The controller Default-Start (which automatically calls Home-Show) renders template homePage.isml
    2. Notice that is is cached for 24 hours: Cached Until time is 24 hours from when you opened this page
    3. 
    4. The Basket-Show remote include renders basket.isml (both from sfra_training cartridge)
    5. The Caching Status is Not Cached, which is what we expect for a basket:
    6. 

1. You can continue testing with the toolkit:
    1. Try the Home-Show route on the URL. Hint: .../Sites-RefArch-Site/en_US/Home-Show
    2. Try using different locales in the URL, like es
    3. Try other tools on the Toolkit: the most usable is the Request Log

Cache settings in Business Manager

So far you have only tested caching on the homepage using the toolkit.  If you need to see caching in action on the instance, you would need to enable caching in Administration >  Sites >  Manage Sites > RefArch - Cache.
Study more about the different settings available for in [Content Cache](https://documentation.b2c.commercecloud.salesforce.com/DOC2/topic/com.demandware.dochelp/content/b2c_commerce/topics/site_development/b2c_content_cache.html) documentation.